### PR TITLE
Adjust Toggle and Menu Alignment in Header

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -6,10 +6,8 @@ function Header(props) {
   return (
     <header class="mx-auto flex max-w-xl justify-between py-10">
       <div class="font-extrabold text-3xl">{props.children}</div>
-      <div class="flex">
-        <div class="mr-3">
-          <ToggleButton />
-        </div>
+      <div class="flex items-center gap-x-3 sm:gap-x-5">
+        <ToggleButton />
         <MenuIcon />
       </div>
     </header>


### PR DESCRIPTION
<div>
<p>Previous Alignment</p>
<img width="359" alt="Screenshot 2024-04-07 at 10 58 06 AM" src="https://github.com/Lumenaries/lumen/assets/105777725/71621364-1641-4dcb-b4ea-02a68dd5c2c3">
</div>

<div>
<p>Current Alignment</p>
<img width="360" alt="Screenshot 2024-04-07 at 10 57 37 AM" src="https://github.com/Lumenaries/lumen/assets/105777725/e27e7cc4-ba32-4fb8-b4b2-1a7a85fc7341">
</div>